### PR TITLE
Fix to run with python3

### DIFF
--- a/alignak_module_nsca/nsca.py
+++ b/alignak_module_nsca/nsca.py
@@ -185,7 +185,7 @@ class NSCACollector(BaseModule):
         """
         # pylint: disable=unused-variable
         iv = bytearray([self.rng.randrange(256) for _ in range(128)])
-        init_packet = struct.pack("!128sI", iv, int(time.time()))
+        init_packet = struct.pack("!128sI", iv.encode('utf-8'), int(time.time()))
         sock.send(init_packet)
         return iv
 


### PR DESCRIPTION
nsca fails on python3 with
WARNING: [receiver-master.alignak.module.nsca] Exception on socket connecting: argument for 's' must be a bytes object

this fixes this error

/pwgen